### PR TITLE
Remove debug print and confirm plan file creation

### DIFF
--- a/src/tests/test_format.py
+++ b/src/tests/test_format.py
@@ -82,11 +82,11 @@ class TestPlanFormatting(unittest.TestCase):
         try:
             # Save the plan to the temporary file
             save_plan_to_file(self.sample_plan, temp_filename)
+            # Confirm that the file was created
+            self.assertTrue(os.path.exists(temp_filename))
 
             # Parse the plan back from the file
             parsed_plan = parse_markdown_to_plan(temp_filename)
-
-            print(f"Parsed plan: {parsed_plan}")
 
             # Check that the parsed plan matches the original
             self.assertEqual(parsed_plan.title, self.sample_plan.title)


### PR DESCRIPTION
## Summary
- remove debug print from `test_save_and_parse_plan`
- assert that the plan file is created before parsing

## Testing
- `pytest -k test_save_and_parse_plan -q`

------
https://chatgpt.com/codex/tasks/task_e_684da4ce52f08327ae4248ca862f2950